### PR TITLE
add printing out testent format address example in wallet create example

### DIFF
--- a/examples/wallet/create_wallet.py
+++ b/examples/wallet/create_wallet.py
@@ -40,6 +40,7 @@ def main() -> None:
     # Print user friendly address https://docs.ton.org/v3/guidelines/dapps/cookbook
     print(f"Testnet address: {wallet.address.to_str(is_test_only=IS_TESTNET)}")
     # Expected testnet bounceable address example: kQCbWHf3WxKD5FtPXYnFAZcPT3aAC8TqdXhHPxNXcHYW_a0Y
+    # Note: For you first transaction you need to use non-bounceable address
     print(f"Mnemonic: {mnemonic}")
 
 

--- a/examples/wallet/create_wallet.py
+++ b/examples/wallet/create_wallet.py
@@ -37,6 +37,9 @@ def main() -> None:
 
     print("Wallet has been successfully created!")
     print(f"Address: {wallet.address.to_str()}")
+    # Print user friendly address https://docs.ton.org/v3/guidelines/dapps/cookbook
+    print(f"Testnet address: {wallet.address.to_str(is_test_only=IS_TESTNET)}")
+    # Expected testnet bounceable address example: kQCbWHf3WxKD5FtPXYnFAZcPT3aAC8TqdXhHPxNXcHYW_a0Y
     print(f"Mnemonic: {mnemonic}")
 
 


### PR DESCRIPTION
It's a little bit confusing to print main net formatted address in that example. So maybe it will be more useful to show actual test net address example