### PR TITLE
fix: swap on dedust with TON as one of asset

### DIFF
--- a/tonutils/jetton/dex/dedust/factory.py
+++ b/tonutils/jetton/dex/dedust/factory.py
@@ -46,7 +46,10 @@ class Asset:
         return Asset(AssetType.JETTON, minter)
 
     def to_cell(self) -> Cell:
-        if not isinstance(self.address, Address):
+        if (
+            not isinstance(self.address, Address)
+            and not self.asset_type == AssetType.NATIVE
+        ):
             raise TypeError("JETTON asset must have a valid Address")
 
         if self.asset_type == AssetType.NATIVE:


### PR DESCRIPTION
Asset.to_cell method waiting for valid address to convert to cell, but TON hasn't it, so method is crashing.
Workaround: if asset_type is TON we don't waiting for valid jetton address

![изображение](https://github.com/user-attachments/assets/604d6261-3030-4105-9dba-a2b40439a5af)
