### PR TITLE
fix: get router v1 while handling exception

### DIFF
--- a/tonutils/jetton/dex/stonfi/utils.py
+++ b/tonutils/jetton/dex/stonfi/utils.py
@@ -32,7 +32,7 @@ async def get_stonfi_router_details(
             decimals=decimals,
         )
 
-    except ValueError:
+    except:
         version = 1
         pton = pton_v1
         offer = resolve_pton_address(offer_address, pton)

--- a/tonutils/jetton/dex/stonfi/utils.py
+++ b/tonutils/jetton/dex/stonfi/utils.py
@@ -32,7 +32,7 @@ async def get_stonfi_router_details(
             decimals=decimals,
         )
 
-    except:
+    except (Exception,):
         version = 1
         pton = pton_v1
         offer = resolve_pton_address(offer_address, pton)


### PR DESCRIPTION
This commit includes small fix while processing v1 router.

I had a specific problem with one token: `EQCSuY0HzfHGfsMTfSSnNXtgqCxrvkO35fcaCESoHApU2L4t`

It has only v1 router and stonfi got an error that does not throw ValueError exception, so v1 router did not return as expected.

So, I fixed it by removing the ValueError exception with handling every exception to try to get v1. It worked!