### PR TITLE
[FEATURE] Add get_jetton_wallets to ToncenterV3Client with response 

### DIFF
--- a/examples/jetton/get_balances.py
+++ b/examples/jetton/get_balances.py
@@ -1,0 +1,25 @@
+from tonutils.client import ToncenterV3Client
+from tonutils.jetton import JettonMasterStandard, JettonWalletStandard
+from tonutils.utils import to_amount
+
+# Set to True for test network, False for main network
+IS_TESTNET = True
+
+# The address of the owner of the Jetton wallet
+OWNER_ADDRESS = "UQ..."
+
+
+async def main() -> None:
+    client = ToncenterV3Client(is_testnet=IS_TESTNET, rps=1, max_retries=1)
+
+    jetton_infos = await client.get_jetton_wallets(owner_address=OWNER_ADDRESS)
+
+    for wallet in jetton_infos.jetton_wallets:
+        print(f"Jetton: {wallet.jetton}, Balance: {wallet.balance}, Owner: {wallet.owner}")
+
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/tonutils/client/models.py
+++ b/tonutils/client/models.py
@@ -1,0 +1,102 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from pytoniq_core import Address
+
+
+@dataclass
+class AddressBookEntry:
+    user_friendly: Address
+    domain: Optional[str] = None
+    interfaces: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "AddressBookEntry":
+        return cls(
+            user_friendly=Address(data["user_friendly"]),
+            domain=data.get("domain"),
+            interfaces=data.get("interfaces", []),
+        )
+
+
+@dataclass
+class JettonWalletInfo:
+    address: Address
+    balance: int
+    owner: Address
+    jetton: Address
+    code_hash: str
+    data_hash: str
+    last_transaction_lt: int
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "JettonWalletInfo":
+        return cls(
+            address=Address(data["address"]),
+            balance=int(data["balance"]),
+            owner=Address(data["owner"]),
+            jetton=Address(data["jetton"]),
+            code_hash=data["code_hash"],
+            data_hash=data["data_hash"],
+            last_transaction_lt=int(data["last_transaction_lt"]),
+        )
+
+
+@dataclass
+class TokenInfo:
+    type: str
+    valid: bool
+    extra: Dict[str, Any] = field(default_factory=dict)
+    name: Optional[str] = None
+    symbol: Optional[str] = None
+    description: Optional[str] = None
+    image: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TokenInfo":
+        return cls(
+            type=data["type"],
+            valid=data["valid"],
+            extra=data.get("extra", {}),
+            name=data.get("name"),
+            symbol=data.get("symbol"),
+            description=data.get("description"),
+            image=data.get("image"),
+        )
+
+
+@dataclass
+class MetadataEntry:
+    is_indexed: bool
+    token_info: List[TokenInfo] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "MetadataEntry":
+        return cls(
+            is_indexed=data["is_indexed"],
+            token_info=[TokenInfo.from_dict(t) for t in data.get("token_info", [])],
+        )
+
+
+@dataclass
+class JettonWalletsResponse:
+    jetton_wallets: List[JettonWalletInfo]
+    address_book: Dict[str, AddressBookEntry]
+    metadata: Dict[str, MetadataEntry]
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "JettonWalletsResponse":
+        return cls(
+            jetton_wallets=[
+                JettonWalletInfo.from_dict(w)
+                for w in data.get("jetton_wallets", [])
+            ],
+            address_book={
+                k: AddressBookEntry.from_dict(v)
+                for k, v in data.get("address_book", {}).items()
+            },
+            metadata={
+                k: MetadataEntry.from_dict(v)
+                for k, v in data.get("metadata", {}).items()
+            },
+        )

--- a/tonutils/client/toncenter.py
+++ b/tonutils/client/toncenter.py
@@ -5,6 +5,7 @@ from pytoniq_core import Address, Builder, Cell, HashMap, Transaction, Slice
 from aiohttp import ClientSession
 
 from ._base import Client
+from .models import JettonWalletsResponse
 from .utils import RunGetMethodStack, RunGetMethodResult, unpack_config
 from ..account import AccountStatus, RawAccount
 from ..utils import boc_to_base64_string
@@ -289,6 +290,47 @@ class ToncenterV3Client(Client):
         client._limiter = self._limiter
 
         return await client.get_config_params()
+
+    async def get_jetton_wallets(
+            self,
+            address: Optional[Union[str, Address]] = None,
+            owner_address: Optional[Union[str, Address]] = None,
+            jetton_address: Optional[Union[str, Address]] = None,
+            exclude_zero_balance: bool = False,
+            limit: int = 10,
+            offset: int = 0,
+            sort: Optional[str] = None,
+    ) -> JettonWalletsResponse:
+        """
+        Get jetton wallets by filter.
+
+        :param address: Jetton wallet address.
+        :param owner_address: Address of the jetton wallet's owner.
+        :param jetton_address: Jetton Master address.
+        :param exclude_zero_balance: Exclude jetton wallets with 0 balance. Defaults to False.
+        :param limit: Maximum number of rows to return. Defaults to 10, max 1000.
+        :param offset: Number of rows to skip. Defaults to 0.
+        :param sort: Sort by balance: "asc" or "desc".
+        :return: JettonWalletsResponse with parsed jetton wallets data.
+        """
+        method = "/jetton/wallets"
+        params: Dict[str, Any] = {
+            "limit": limit,
+            "offset": offset,
+            "exclude_zero_balance": str(exclude_zero_balance).lower(),
+        }
+
+        if address is not None:
+            params["address"] = address.to_str() if isinstance(address, Address) else address
+        if owner_address is not None:
+            params["owner_address"] = owner_address.to_str() if isinstance(owner_address, Address) else owner_address
+        if jetton_address is not None:
+            params["jetton_address"] = jetton_address.to_str() if isinstance(jetton_address, Address) else jetton_address
+        if sort is not None:
+            params["sort"] = sort
+
+        result = await self._get(method=method, params=params)
+        return JettonWalletsResponse.from_dict(result)
 
     async def get_transactions(
             self,


### PR DESCRIPTION
Add get_jetton_wallets to ToncenterV3Client with response  dataclasses

   Support querying /api/v3/jetton/wallets endpoint with typed response
   models (JettonWalletsResponse, JettonWalletInfo, AddressBookEntry,
   MetadataEntry, TokenInfo) that parse all addresses as Address objects. Key elements stay as not userfriendly